### PR TITLE
bcm27xx/bcm2712: add rp1 kmods

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -745,21 +745,3 @@ endef
 $(eval $(call KernelPackage,hwmon-adcxx))
 
 
-define KernelPackage/hwmon-rp1-adc
-  TITLE:=RP1 ADC driver
-  KCONFIG:= \
-	    CONFIG_SENSORS_RP1_ADC=y \
-	    CONFIG_MFD_RP1=y \
-	    CONFIG_MFD_CORE=y \
-	    CONFIG_PWM_RP1=y \
-	    CONFIG_COMMON_CLK_RP1=y
-  FILES:=$(LINUX_DIR)/drivers/hwmon/rp1-adc.ko
-  AUTOLOAD:=$(call AutoLoad,60,rp1_adc)
-  $(call AddDepends/hwmon,)
-endef
-
-define KernelPackage/hwmon-rp1-adc/description
-  RP1 ADC driver
-endef
-
-$(eval $(call KernelPackage,hwmon-rp1-adc))

--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -745,3 +745,21 @@ endef
 $(eval $(call KernelPackage,hwmon-adcxx))
 
 
+define KernelPackage/hwmon-rp1-adc
+  TITLE:=RP1 ADC driver
+  KCONFIG:= \
+	    CONFIG_SENSORS_RP1_ADC=y \
+	    CONFIG_MFD_RP1=y \
+	    CONFIG_MFD_CORE=y \
+	    CONFIG_PWM_RP1=y \
+	    CONFIG_COMMON_CLK_RP1=y
+  FILES:=$(LINUX_DIR)/drivers/hwmon/rp1-adc.ko
+  AUTOLOAD:=$(call AutoLoad,60,rp1_adc)
+  $(call AddDepends/hwmon,)
+endef
+
+define KernelPackage/hwmon-rp1-adc/description
+  RP1 ADC driver
+endef
+
+$(eval $(call KernelPackage,hwmon-rp1-adc))

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -1044,14 +1044,9 @@ define KernelPackage/rp1
   KCONFIG:= \
            CONFIG_FIRMWARE_RP1 \
            CONFIG_RP1_PIO \
-           CONFIG_PINCTRL_RP1=y \
-           CONFIG_SENSORS_RP1_ADC \
-           CONFIG_MFD_RP1=y \
-           CONFIG_COMMON_CLK_RP1=y \
            CONFIG_COMMON_CLK_RP1_SDIO=y \
            CONFIG_MBOX_RP1 \
-           CONFIG_PWM_PIO_RP1 \
-           CONFIG_PWM_RP1=y
+           CONFIG_PWM_PIO_RP1
   FILES:= \
            $(LINUX_DIR)/drivers/firmware/rp1.ko \
            $(LINUX_DIR)/drivers/mailbox/rp1-mailbox.ko \

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -584,16 +584,6 @@ endef
 $(eval $(call KernelPackage,mfd))
 
 
-define KernelPackage/rp1
-  SUBMENU:=$(OTHER_MENU)
-  TITLE:=RP1 wrapper
-  FILES:=$(LINUX_DIR)/drivers/firmware/rp1.ko
-  AUTOLOAD:=$(call AutoLoad,10,rp1)
-endef
-
-$(eval $(call KernelPackage,rp1))
-
-
 define KernelPackage/mtdtests
   SUBMENU:=$(OTHER_MENU)
   TITLE:=MTD subsystem tests
@@ -893,20 +883,6 @@ define KernelPackage/pps-gpio/description
 endef
 
 $(eval $(call KernelPackage,pps-gpio))
-
-
-define KernelPackage/rp1-pio
-  SUBMENU:=$(OTHER_MENU)
-  TITLE:=PIO controller driver for Raspberry Pi RP1
-  FILES:=$(LINUX_DIR)/drivers/misc/rp1-pio.ko
-  AUTOLOAD:=$(call AutoLoad,18,rp1-pio,1)
-endef
-
-define KernelPackage/rp1-pio/description
-PIO controller driver for Raspberry Pi RP1
-endef
-
-$(eval $(call KernelPackage,rp1-pio))
 
 
 define KernelPackage/pps-ldisc

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -1038,6 +1038,34 @@ endef
 $(eval $(call KernelPackage,keys-trusted))
 
 
+define KernelPackage/rp1
+  TITLE:=RP1 title
+  DEPENDS:=+kmod-hwmon-core
+  KCONFIG:= \
+           CONFIG_FIRMWARE_RP1 \
+           CONFIG_RP1_PIO \
+           CONFIG_PINCTRL_RP1=y \
+           CONFIG_SENSORS_RP1_ADC \
+           CONFIG_MFD_RP1=y \
+           CONFIG_COMMON_CLK_RP1=y \
+           CONFIG_COMMON_CLK_RP1_SDIO=y \
+           CONFIG_MBOX_RP1 \
+           CONFIG_PWM_PIO_RP1 \
+           CONFIG_PWM_RP1=y
+  FILES:= \
+           $(LINUX_DIR)/drivers/firmware/rp1.ko \
+           $(LINUX_DIR)/drivers/mailbox/rp1-mailbox.ko \
+           $(LINUX_DIR)/drivers/misc/rp1-pio.ko \
+           $(LINUX_DIR)/drivers/pwm/pwm-pio-rp1.ko
+  AUTOLOAD:=$(call AutoLoad,10,rp1)
+endef
+
+define KernelPackage/rp1/description
+  RP1 modules
+endef
+
+$(eval $(call KernelPackage,rp1))
+
 define KernelPackage/tpm
   SUBMENU:=$(OTHER_MENU)
   TITLE:=TPM Hardware Support

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -584,6 +584,16 @@ endef
 $(eval $(call KernelPackage,mfd))
 
 
+define KernelPackage/rp1
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=RP1 wrapper
+  FILES:=$(LINUX_DIR)/drivers/firmware/rp1.ko
+  AUTOLOAD:=$(call AutoLoad,10,rp1)
+endef
+
+$(eval $(call KernelPackage,rp1))
+
+
 define KernelPackage/mtdtests
   SUBMENU:=$(OTHER_MENU)
   TITLE:=MTD subsystem tests
@@ -883,6 +893,20 @@ define KernelPackage/pps-gpio/description
 endef
 
 $(eval $(call KernelPackage,pps-gpio))
+
+
+define KernelPackage/rp1-pio
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=PIO controller driver for Raspberry Pi RP1
+  FILES:=$(LINUX_DIR)/drivers/misc/rp1-pio.ko
+  AUTOLOAD:=$(call AutoLoad,18,rp1-pio,1)
+endef
+
+define KernelPackage/rp1-pio/description
+PIO controller driver for Raspberry Pi RP1
+endef
+
+$(eval $(call KernelPackage,rp1-pio))
 
 
 define KernelPackage/pps-ldisc

--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -201,7 +201,8 @@ define Device/rpi-5
 	cypress-firmware-43455-sdio \
 	brcmfmac-nvram-43455-sdio \
 	kmod-brcmfmac wpad-basic-mbedtls \
-	kmod-hwmon-pwmfan kmod-thermal
+	kmod-hwmon-pwmfan kmod-thermal \
+	kmod-hwmon-rp1-adc kmod-rp1 kmod-rp1-pio
   IMAGE/sysupgrade.img.gz := boot-common | sdcard-img | gzip | append-metadata
   IMAGE/factory.img.gz := boot-common | sdcard-img | gzip
 endef

--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -201,7 +201,7 @@ define Device/rpi-5
 	cypress-firmware-43455-sdio \
 	brcmfmac-nvram-43455-sdio \
 	kmod-brcmfmac wpad-basic-mbedtls \
-	kmod-hwmon-pwmfan kmod-thermal
+	kmod-hwmon-pwmfan kmod-thermal kmod-rp1
   IMAGE/sysupgrade.img.gz := boot-common | sdcard-img | gzip | append-metadata
   IMAGE/factory.img.gz := boot-common | sdcard-img | gzip
 endef

--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -201,8 +201,7 @@ define Device/rpi-5
 	cypress-firmware-43455-sdio \
 	brcmfmac-nvram-43455-sdio \
 	kmod-brcmfmac wpad-basic-mbedtls \
-	kmod-hwmon-pwmfan kmod-thermal \
-	kmod-hwmon-rp1-adc kmod-rp1 kmod-rp1-pio
+	kmod-hwmon-pwmfan kmod-thermal
   IMAGE/sysupgrade.img.gz := boot-common | sdcard-img | gzip | append-metadata
   IMAGE/factory.img.gz := boot-common | sdcard-img | gzip
 endef


### PR DESCRIPTION
Attempt to add the following config options:
CONFIG_SENSORS_RP1_ADC=y
CONFIG_MFD_RP1=y
CONFIG_COMMON_CLK_RP1=y
CONFIG_PWM_RP1=y

And corresponding modules:
rp1
rp1_adc
rp1_pio